### PR TITLE
Splitting string that has consecutive delimiters gives unexpected results

### DIFF
--- a/bstring/bstrlib.c
+++ b/bstring/bstrlib.c
@@ -2619,7 +2619,8 @@ bsplitstrcb(const bstring str, const bstring splitStr, int pos,
 	if (splitStr->slen == 1) {
 		return bsplitcb(str, splitStr->data[0], pos, cb, parm);
 	}
-	for (i = p = pos; i <= str->slen - splitStr->slen; i++) {
+	i = p = pos;
+	while (i <= str->slen - splitStr->slen) {
 		ret = memcmp(splitStr->data, str->data + i, splitStr->slen);
 		if (0 == ret) {
 			ret = cb (parm, p, i - p);
@@ -2628,6 +2629,8 @@ bsplitstrcb(const bstring str, const bstring splitStr, int pos,
 			}
 			i += splitStr->slen;
 			p = i;
+		} else {
+			i++;
 		}
 	}
 	ret = cb (parm, p, str->slen - p);

--- a/tests/bstest.c
+++ b/tests/bstest.c
@@ -1257,6 +1257,12 @@ START_TEST(core_021)
 {
 	struct tagbstring is = bsStatic ("is");
 	struct tagbstring ng = bsStatic ("ng");
+	struct tagbstring delim = bsStatic("aa");
+	struct tagbstring beginWithDelim = bsStatic("aaabcdaa1");
+	struct tagbstring endWithDelim = bsStatic("1aaabcdaa");
+	struct tagbstring conseqDelim = bsStatic("1aaaa1");
+	struct tagbstring oneCharLeft = bsStatic("aaaaaaa");
+	struct tagbstring allDelim = bsStatic("aaaaaa");
 	int ret = 0;
 	/* tests with NULL */
 	test21_0(NULL, (char) '?', 0);
@@ -1275,6 +1281,14 @@ START_TEST(core_021)
 	test21_1(&shortBstring, &emptyBstring, 5);
 	test21_1(&longBstring, &is, 3);
 	test21_1(&longBstring, &ng, 5);
+	/* corner cases */
+	test21_1(&emptyBstring, &delim, 1);
+	test21_1(&delim, &delim, 2);
+	test21_1(&beginWithDelim, &delim, 3);
+	test21_1(&endWithDelim, &delim, 3);
+	test21_1(&conseqDelim, &delim, 3);
+	test21_1(&oneCharLeft, &delim, 4);
+	test21_1(&allDelim, &delim, 4);
 	struct bstrList * l;
 	unsigned char c;
 	struct tagbstring t;


### PR DESCRIPTION

Expected behavior:
split("a SPLITSPLIT b", "SPLIT") ---> ["a ", "", " b"]
Observed behavior:
split("a SPLITSPLIT b", "SPLIT") ---> ["a ", "SPLIT b"]
Within the loop in bsplitstrcb, i is sent too far forward
upon finding a match. Here is a proposed fix including tests,
open to suggestions. A few more details in the GH pull request.