### PR TITLE
Port improvements from bstrlib and netatalk fork

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,3 +1,6 @@
+Copyright (c) 2002-2015 Paul Hsieh
+All rights reserved.
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 

--- a/bstring/bstraux.c
+++ b/bstring/bstraux.c
@@ -1,4 +1,4 @@
-/* Copyright 2002-2010 Paul Hsieh
+/* Copyright 2002-2015 Paul Hsieh
  * This file is part of Bstrlib.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/bstring/bstraux.h
+++ b/bstring/bstraux.h
@@ -1,4 +1,4 @@
-/* Copyright 2002-2010 Paul Hsieh
+/* Copyright 2002-2015 Paul Hsieh
  * This file is part of Bstrlib.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/bstring/bstrlib.c
+++ b/bstring/bstrlib.c
@@ -1,4 +1,4 @@
-/* Copyright 2002-2010 Paul Hsieh
+/* Copyright 2002-2015 Paul Hsieh
  * This file is part of Bstrlib.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/bstring/bstrlib.c
+++ b/bstring/bstrlib.c
@@ -144,6 +144,12 @@ retry:
 		b->data = x;
 		b->mlen = len;
 		b->data[b->slen] = (unsigned char)'\0';
+
+#if defined (BSTRLIB_TEST_CANARY)
+		if (len > b->slen + 1) {
+			memchr (b->data + b->slen + 1, 'X', len - (b->slen + 1));
+		}
+#endif
 	}
 	return BSTR_OK;
 }

--- a/bstring/bstrlib.c
+++ b/bstring/bstrlib.c
@@ -1823,7 +1823,7 @@ breada(bstring b, bNread readPtr, void *parm)
 	int i, l, n;
 	if (b == NULL || b->mlen <= 0 ||
 	    b->slen < 0 || b->mlen < b->slen ||
-	    b->mlen <= 0 || readPtr == NULL) {
+	    readPtr == NULL) {
 		return BSTR_ERR;
 	}
 	i = b->slen;
@@ -1859,7 +1859,7 @@ bassigngets(bstring b, bNgetc getcPtr, void *parm, char terminator)
 	int c, d, e;
 	if (!b || b->mlen <= 0 ||
 	    b->slen < 0 || b->mlen < b->slen ||
-	    b->mlen <= 0 || getcPtr == NULL) {
+	    getcPtr == NULL) {
 		return BSTR_ERR;
 	}
 	d = 0;
@@ -1889,7 +1889,7 @@ bgetsa(bstring b, bNgetc getcPtr, void *parm, char terminator)
 	int c, d, e;
 	if (!b || b->mlen <= 0 ||
 	    b->slen < 0 || b->mlen < b->slen ||
-	    b->mlen <= 0 || !getcPtr) {
+	    !getcPtr) {
 		return BSTR_ERR;
 	}
 	d = b->slen;

--- a/bstring/bstrlib.c
+++ b/bstring/bstrlib.c
@@ -2929,6 +2929,7 @@ bvcformata(bstring b, int count, const char *fmt, va_list arg)
 		return BSTR_ERR;
 	}
 	exvsnprintf(r, (char *)b->data + b->slen, count + 2, fmt, arg);
+	b->data[b->slen + count + 2] = '\0';
 	/* Did the operation complete successfully within bounds? */
 	for (l = b->slen; l <= n; l++) {
 		if ('\0' == b->data[l]) {

--- a/bstring/bstrlib.c
+++ b/bstring/bstrlib.c
@@ -269,7 +269,12 @@ blk2bstr(const void *blk, int len)
 	if (len > 0) {
 		memcpy(b->data, blk, len);
 	}
-	b->data[len] = (unsigned char)'\0';
+	if (b->mlen > len) {
+	    b->data[len] = (unsigned char)'\0';
+	} else {
+		free(b);
+		return NULL;
+	}
 	return b;
 }
 
@@ -2298,7 +2303,7 @@ bjoin(const struct bstrList *bl, const bstring sep)
 	if (bl == NULL || bl->qty < 0) {
 		return NULL;
 	}
-	if (sep != NULL && (sep->slen < 0 || sep->data == NULL)) {
+	if (sep == NULL || sep->slen < 0 || sep->data == NULL) {
 		return NULL;
 	}
 	for (i = 0, c = 1; i < bl->qty; i++) {

--- a/bstring/bstrlib.c
+++ b/bstring/bstrlib.c
@@ -981,7 +981,9 @@ bdestroy(bstring b)
 	    b->data == NULL) {
 		return BSTR_ERR;
 	}
-	free(b->data);
+	if (b->data != NULL) {
+		free(b->data);
+	}
 	/* In case there is any stale usage, there is one more chance to
 	 * notice this error.
 	 */

--- a/bstring/bstrlib.h
+++ b/bstring/bstrlib.h
@@ -1,4 +1,4 @@
-/* Copyright 2002-2010 Paul Hsieh
+/* Copyright 2002-2015 Paul Hsieh
  * This file is part of Bstrlib.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/doc/comparisons.md
+++ b/doc/comparisons.md
@@ -554,3 +554,28 @@ essence, would allow the compiler to enforce trust propogation at compile
 time rather than run time. Non-resizability is also interesting, however,
 it seems marginal, i.e., to want a string that cannot be resized, yet can be
 modified and yet where a fixed sized buffer is undesirable.
+
+Libsrt
+------
+
+This is a length based string library based on a slightly different strategy.
+The string contents are appended to the end of the header directly so strings
+only require a single allocation.  However, whenever a reallocation occurs,
+the header is replicated and the base pointer for the string is changed.
+That means references to the string are only valid so long as they are not
+resized after any such reference is cached.  The internal structure maintains
+a lot some state used to accelerate unicode manipulation.  This state is
+dynamically updated according to usage (so, like Bstrlib, it supports both
+a binary mode and a Unicode mode basically all the time).  But this makes
+sustainable usage of the library essentially opaque.  This also creates a
+bottleneck for whatever extensions to the library one desires (write all
+extensions on top of the base library, put in a request to the author, or
+dedicate an expert to learn the internals of the library).
+
+SDS
+---
+
+Sds uses a strategy very similar to Libsrt.  However, it uses some dynamic
+headers to decrease the overhead for very small strings.  This requires an
+extra switch statement for access to each string attribute.  The source code
+appears to use gcc/clang extensions, and thus it is not portable.

--- a/doc/security.md
+++ b/doc/security.md
@@ -69,17 +69,18 @@ all their code from a functionality point of view.
 
 ### Memory Size Overflow/Wrap Around Attack
 
-Bstrlib is impervious to memory size overflow attacks by design. The
-reason is it is resiliant to length overflows is that bstring lengths are
-bounded above by `INT_MAX`, instead of `~(size_t)0`. So length addition
-overflows cause a wrap around of the integer value making them negative
-causing `balloc` to fail before an erroneous operation can occurr. Attempted
-conversions of `char *` strings which may have lengths greater than `INT_MAX`
-are detected and the conversion is aborted.
+By design, Bstrlib is impervious to memory size overflow attacks.  The
+reason is that it detects length overflows and leads to a result error before
+the operation attempts to proceed.  Attempted conversions of char* strings
+which may have lengths greater than INT_MAX are detected and the conversion
+is aborted.  If the memory to hold the string exceeds the available memory
+for it, again, the result is aborted without changing the prior state of the
+strings.
 
-It is unknown if this property holds on machines that don't represent integers
-as 2s complement. It is recommended that Bstrlib be carefully auditted by
-anyone using a system which is not 2s complement based.
+These behaviors rely on the use of 2s complement by the underlying machine
+architecture.  It is unknown if these properties hold on machines that do
+not represent integers as 2s complement.  It is recommended that Bstrlib be
+carefully auditted by anyone using a system which is not 2s complement based.
 
 ### Constant String Protection
 

--- a/doc/security.md
+++ b/doc/security.md
@@ -25,11 +25,11 @@ OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 Like any software, there is always a possibility of failure due to a flawed
-implementation. Nevertheless a good faith effort has been made to minimize
-such flaws in Bstrlib. Also, use of Bstrlib by itself will not make an
-application secure or free from implementation failures. However, it is the
-author's conviction that use of Bstrlib can greatly facilitate the creation
-of software meeting the highest possible standards of security.
+implementation.  Nevertheless a good faith effort has been made to minimize
+such flaws in Bstrlib.  Use of Bstrlib by itself will not make an application
+secure or free from implementation failures, however, it is the author's
+conviction that use of Bstrlib can greatly facilitate the creation of
+software meeting the highest possible standards of security.
 
 Part of the reason why this document has been created, is for the purpose of
 security auditing, or the creation of further "Statements on Security" for
@@ -76,11 +76,6 @@ which may have lengths greater than INT_MAX are detected and the conversion
 is aborted.  If the memory to hold the string exceeds the available memory
 for it, again, the result is aborted without changing the prior state of the
 strings.
-
-These behaviors rely on the use of 2s complement by the underlying machine
-architecture.  It is unknown if these properties hold on machines that do
-not represent integers as 2s complement.  It is recommended that Bstrlib be
-carefully auditted by anyone using a system which is not 2s complement based.
 
 ### Constant String Protection
 
@@ -204,5 +199,5 @@ Obscure Issues
 
 ### Data attributes
 
-There is no support for a Perl-like "taint" attribute, however, an example of
-how to do this using C++'s type system is given as an example.
+There is no support for a Perl-like "taint" attribute, although this is a
+fairly straightforward exercise using C++'s type system.

--- a/tests/bstest.c
+++ b/tests/bstest.c
@@ -1,4 +1,4 @@
-/* Copyright 2002-2010 Paul Hsieh
+/* Copyright 2002-2015 Paul Hsieh
  * This file is part of Bstrlib.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/tests/bstest.c
+++ b/tests/bstest.c
@@ -89,6 +89,8 @@ test0_1(const char *s, int len, const char *res)
 
 #define SHORT_STRING "bogus"
 
+#define EIGHT_CHAR_STRING "Waterloo"
+
 #define LONG_STRING  \
 	"This is a bogus but reasonably long string.  " \
 	"Just long enough to cause some mallocing."
@@ -2899,7 +2901,7 @@ test46_1(bstring b, const char * fmt, const bstring r, ...)
 
 START_TEST(core_046)
 {
-	bstring b;
+	bstring b, b2;
 	int ret = 0;
 	test46_0(NULL, NULL, 8, "[%d]", 15);
 	test46_0(NULL, &shortBstring, 8, "[%d]", 15);
@@ -2925,6 +2927,15 @@ START_TEST(core_046)
 	test46_1(b, "%s", &shortBstring, (char *)shortBstring.data);
 	b->slen = 0;
 	test46_1(b, "%s", &longBstring, (char *)longBstring.data);
+    b->slen = 0;
+	b2 = bfromcstr(EIGHT_CHAR_STRING);
+	bconcat(b2, b2);
+	bconcat(b2, b2);
+	bconcat(b2, b2);
+	test46_1(b, "%s%s%s%s%s%s%s%s", b2,
+	         EIGHT_CHAR_STRING, EIGHT_CHAR_STRING, EIGHT_CHAR_STRING, EIGHT_CHAR_STRING,
+	         EIGHT_CHAR_STRING, EIGHT_CHAR_STRING, EIGHT_CHAR_STRING, EIGHT_CHAR_STRING);
+	bdestroy(b2);
 	ret = bdestroy(b);
 	ck_assert_int_eq(ret, BSTR_OK);
 }

--- a/tests/testaux.c
+++ b/tests/testaux.c
@@ -1,4 +1,4 @@
-/* Copyright 2002-2010 Paul Hsieh
+/* Copyright 2002-2015 Paul Hsieh
  * This file is part of Bstrlib.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
This ports patches from two sources: The upstream [bstrlib project](https://github.com/websnarf/bstrlib) by Paul Hsieh (websnarf), and the [netatalk fork](https://github.com/Netatalk/bstrlib) of the same.

- Memory safety fixes
- Unit test improvements
- Documentation improvements