### PR TITLE
Modern Meson build system + GitHub build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,352 @@
+name: Builds
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions: read-all
+
+jobs:
+  build-alpine:
+    name: Alpine Linux
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    container:
+      image: alpine:latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Install dependencies
+        run: |
+          apk add \
+            build-base \
+            check \
+            check-dev \
+            gcc \
+            meson \
+            ninja \
+            pkgconfig
+      - name: Configure
+        run: |
+          meson setup build \
+            -Denable-tests=true
+      - name: Build
+        run: meson compile -C build
+      - name: Run unit tests
+        run: meson test -C build
+      - name: Install
+        run: meson install -C build
+      - name: Uninstall
+        run: ninja -C build uninstall
+
+  build-archlinux:
+    name: Arch Linux
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    container:
+      image: archlinux:latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Install dependencies
+        run: |
+          pacman -Sy --noconfirm \
+            check \
+            gcc \
+            meson \
+            ninja \
+            pkgconfig
+      - name: Configure
+        run: |
+          meson setup build \
+            -Denable-tests=true
+      - name: Build
+        run: meson compile -C build
+      - name: Run unit tests
+        run: meson test -C build
+      - name: Install
+        run: meson install -C build
+      - name: Uninstall
+        run: ninja -C build uninstall
+
+  build-debian:
+    name: Debian Linux
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    container:
+      image: debian:latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install --assume-yes --no-install-recommends \
+            build-essential \
+            check \
+            meson \
+            ninja-build \
+            pkg-config
+      - name: Configure
+        run: |
+          meson setup build \
+            -Denable-tests=true
+      - name: Build
+        run: meson compile -C build
+      - name: Run unit tests
+        run: meson test -C build
+      - name: Install
+        run: meson install -C build
+      - name: Uninstall
+        run: ninja -C build uninstall
+
+  build-fedora:
+    name: Fedora Linux
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    container:
+      image: fedora:latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Install dependencies
+        run: |
+          dnf --setopt=install_weak_deps=False --assumeyes install \
+            check \
+            check-devel \
+            gcc \
+            meson \
+            ninja-build
+      - name: Configure
+        run: |
+          meson setup build \
+            -Denable-tests=true
+      - name: Build
+        run: meson compile -C build
+      - name: Run unit tests
+        run: meson test -C build
+      - name: Install
+        run: sudo meson install -C build
+      - name: Uninstall
+        run: sudo ninja -C build uninstall
+
+  build-ubuntu:
+    name: Ubuntu Linux
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --assume-yes --no-install-recommends \
+            check \
+            meson \
+            ninja-build
+      - name: Configure
+        run: |
+          meson setup build \
+            -Denable-tests=true
+      - name: Build
+        run: meson compile -C build
+      - name: Run unit tests
+        run: meson test -C build
+      - name: Install
+        run: sudo meson install -C build
+      - name: Uninstall
+        run: sudo ninja -C build uninstall
+
+  build-macos:
+    name: macOS
+    runs-on: macos-latest
+    timeout-minutes: 2
+    env:
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Install dependencies
+        run: |
+          brew update
+          brew install \
+            check \
+            meson
+      - name: Configure
+        run: |
+          meson setup build \
+            -Denable-tests=true
+      - name: Build
+        run: meson compile -C build
+      - name: Run unit tests
+        run: meson test -C build
+      - name: Install
+        run: sudo meson install -C build
+      - name: Uninstall
+        run: sudo ninja -C build uninstall
+
+  build-dflybsd:
+    name: DragonflyBSD
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Build on VM
+        uses: vmactions/dragonflybsd-vm@e3c420e8a2362c2496fca6e76a291abd46f5d8e7
+        with:
+          copyback: false
+          usesh: true
+          prepare: |
+            pkg install -y \
+              check \
+              meson \
+              pkgconf
+          run: |
+            set -e
+            meson setup build \
+              -Denable-tests=true
+            meson compile -C build
+            meson test -C build
+            meson install -C build
+            ninja -C build uninstall
+
+  build-freebsd:
+    name: FreeBSD
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Build on VM
+        uses: vmactions/freebsd-vm@966989c456d41351f095a421f60e71342d3bce41
+        with:
+          copyback: false
+          prepare: |
+            pkg install -y \
+              check \
+              meson \
+              pkgconf
+          run: |
+            set -e
+            meson setup build \
+              -Denable-tests=true
+            meson compile -C build
+            meson test -C build
+            meson install -C build
+            ninja -C build uninstall
+
+  build-netbsd:
+    name: NetBSD
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Build on VM
+        uses: vmactions/netbsd-vm@46a58bbf03682b4cb24142b97fa315ae52bed573
+        with:
+          copyback: false
+          prepare: |
+            export PKG_PATH="http://ftp.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/$(uname -r|cut -f '1 2' -d.)/All/"
+            pkg_add \
+              check \
+              meson \
+              pkg-config
+          run: |
+            set -e
+            meson setup build \
+              -Denable-tests=true
+            meson compile -C build
+            meson test -C build
+            meson install -C build
+            ninja -C build uninstall
+
+  build-openbsd:
+    name: OpenBSD
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Build on VM
+        uses: vmactions/openbsd-vm@0d65352eee1508bab7cb12d130536d3a556be487
+        with:
+          copyback: false
+          prepare: |
+            pkg_add -I \
+              check \
+              meson \
+              pkgconf
+          run: |
+            set -e
+            meson setup build \
+              -Denable-tests=true
+            meson compile -C build
+            meson test -C build
+            meson install -C build
+            ninja -C build uninstall
+
+  build-omnios:
+    name: OmniOS
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Build on VM
+        uses: vmactions/omnios-vm@8eba2a9217262f275d4566751a92d6ef2f433d00
+        with:
+          copyback: false
+          prepare: |
+            pkg install \
+              build-essential \
+              pkg-config
+            curl -O https://pkgsrc.smartos.org/packages/SmartOS/bootstrap/bootstrap-trunk-x86_64-20240116.tar.gz
+            tar -zxpf bootstrap-trunk-x86_64-20240116.tar.gz -C /
+            export PATH=/opt/local/sbin:/opt/local/bin:/usr/gnu/bin:/usr/bin:/usr/sbin:/sbin:$PATH
+            pkgin -y install \
+              check \
+              meson
+          run: |
+            set -e
+            export PATH=/opt/local/sbin:/opt/local/bin:/usr/gnu/bin:/usr/bin:/usr/sbin:/sbin:$PATH
+            meson setup build \
+              -Denable-tests=true \
+              -Dpkg_config_path=/opt/local/lib/pkgconfig
+            meson compile -C build
+            meson test -C build
+            meson install -C build
+            ninja -C build uninstall
+
+  build-solaris:
+    name: Solaris
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Build on VM
+        uses: vmactions/solaris-vm@170f1f96f376cf7467cc41627e0c7590932fccaa
+        with:
+          copyback: false
+          prepare: |
+            set -e
+            pkg install \
+              check \
+              gcc \
+              meson \
+              ninja \
+              pkg-config
+          run: |
+            set -e
+            export PATH=/usr/local/sbin:/usr/local/bin:$PATH
+            meson setup build \
+              -Denable-tests=true \
+              -Dpkg_config_path=/usr/lib/amd64/pkgconfig
+            meson compile -C build
+            meson test -C build
+            meson install -C build
+            ninja -C build uninstall

--- a/bstring/meson.build
+++ b/bstring/meson.build
@@ -1,0 +1,13 @@
+install_headers(['bstraux.h', 'bstrlib.h'])
+
+libbstring = library(
+    meson.project_name(),
+    ['bstraux.c', 'bstrlib.c'],
+    version: '1.0.0',
+    soversion: '1',
+    include_directories: bstring_inc,
+    install: true,
+    install_dir: get_option('libdir'),
+)
+
+bstring_dep = declare_dependency(include_directories: bstring_inc, link_with: libbstring)

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -52,7 +52,7 @@ PROJECT_LOGO           =
 # If a relative path is entered, it will be relative to the location
 # where doxygen was started. If left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = doc
+OUTPUT_DIRECTORY       = @OUTPUT_DIR@
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create
 # 4096 sub-directories (in 2 levels) under the output directory of each output
@@ -668,8 +668,8 @@ WARN_LOGFILE           =
 # directories like "/usr/src/myproject". Separate the files or directories
 # with spaces.
 
-INPUT                  = @abs_top_srcdir@/doc @abs_top_srcdir@/bstring
-USE_MDFILE_AS_MAINPAGE = @abs_top_srcdir@/doc/introduction.md
+INPUT                  = @ABS_TOP_SRCDIR@/doc @ABS_TOP_SRCDIR@/bstring
+USE_MDFILE_AS_MAINPAGE = @ABS_TOP_SRCDIR@/doc/introduction.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,0 +1,16 @@
+doxyfile_conf = configuration_data()
+doxyfile_conf.set('PROJECT_VERSION', meson.project_version())
+doxyfile_conf.set('PACKAGE', meson.project_name())
+doxyfile_conf.set('VERSION', meson.project_version())
+doxyfile_conf.set('ABS_TOP_SRCDIR', meson.project_source_root())
+doxyfile_conf.set('OUTPUT_DIR', meson.current_build_dir())
+
+doxyfile = configure_file(input: 'Doxyfile.in', output: 'Doxyfile', configuration: doxyfile_conf)
+
+run_command(doxygen, doxyfile, check: true)
+
+install_subdir(
+    meson.current_build_dir() / 'html',
+    install_dir: get_option('datadir') / 'doc' / meson.project_name(),
+    strip_directory: false,
+)

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,42 @@
+project('bstring', 'c', version: '1.0.0', default_options: ['warning_level=2'])
+cc = meson.get_compiler('c')
+pkg = import('pkgconfig')
+
+add_project_arguments('-pedantic', language: 'c')
+add_project_arguments('-Wstrict-prototypes', language: 'c')
+add_project_arguments('-Wcast-align', language: 'c')
+add_project_arguments('-Wno-gnu', language: 'c')
+add_project_arguments('-fno-common', language: 'c')
+add_project_arguments('-fvisibility=hidden', language: 'c')
+
+bstring_inc = include_directories(['.', 'bstring'])
+
+subdir('bstring')
+
+pkg.generate(
+    libbstring,
+    name: meson.project_name(),
+    description: 'The Better String Library',
+    version: meson.project_version(),
+    subdirs: ['bstring'],
+)
+
+check = dependency('check', required: false)
+
+if get_option('enable-tests')
+    if check.found()
+        subdir('tests')
+    else
+        error('Tests requested but check library not found')
+    endif
+endif
+
+doxygen = find_program('doxygen', required: false)
+
+if get_option('enable-docs')
+    if doxygen.found()
+        subdir('doc')
+    else
+        error('Docs requested but doxygen not found')
+    endif
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,12 @@
+option(
+    'enable-docs',
+    type: 'boolean',
+    value: false,
+    description: 'Generate and install documentation',
+)
+option(
+    'enable-tests',
+    type: 'boolean',
+    value: false,
+    description: 'Build unit tests',
+)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,17 @@
+test_executable = executable(
+    'bstest',
+    'bstest.c',
+    link_with: libbstring,
+    include_directories: bstring_inc,
+    dependencies: check,
+)
+test_executable_aux = executable(
+    'testaux',
+    'testaux.c',
+    link_with: libbstring,
+    include_directories: bstring_inc,
+    dependencies: check,
+)
+
+test('bstring unit tests', test_executable)
+test('bstring auxiliary unit tests', test_executable_aux)


### PR DESCRIPTION
Introduces Meson build scripts for building and installing bstring. Also includes a GitHub workflow for demonstrating the build system.

The difference with https://github.com/msteinert/bstring/pull/2 is first of all 6 years of Meson development. My version can also handle docs with doxygen, unit tests with check, pkg-config pc file, and a dependency declaration so that bstring can be used as a subproject in other Meson projects.

My motivation here is namely that I want to use this library as a subproject in another Meson project (Netatalk) rather than having a vendored copy of the code in our own repo.

Quick start guide to Meson:

```
meson setup build -Denable-docs=true -Denable-tests=true
meson compile -C build
meson test -C build
sudo meson install -C build
```
