### PR TITLE
Compatibility with Solaris standard C library

### DIFF
--- a/bstring/bstraux.c
+++ b/bstring/bstraux.c
@@ -32,7 +32,7 @@
  */
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+#include <config.h>
 #endif
 
 #ifdef _MSC_VER

--- a/bstring/bstraux.h
+++ b/bstring/bstraux.h
@@ -42,6 +42,10 @@
 #ifndef BSTRAUX_H
 #define BSTRAUX_H
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <time.h>
 #include <bstrlib.h>
 

--- a/bstring/bstrlib.c
+++ b/bstring/bstrlib.c
@@ -36,7 +36,7 @@
  */
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+#include <config.h>
 #endif
 
 #if defined (_MSC_VER)
@@ -1943,7 +1943,11 @@ bgetsa(bstring b, bNgetc getcPtr, void *parm, char terminator)
 }
 
 bstring
+#if defined(HAVE_LIBGEN_H_BGETS)
+bgetstream(bNgetc getcPtr, void *parm, char terminator)
+#else
 bgets(bNgetc getcPtr, void *parm, char terminator)
+#endif
 {
 	bstring buff;
 	if (0 > bgetsa(buff = bfromcstr (""), getcPtr, parm, terminator) ||

--- a/bstring/bstrlib.h
+++ b/bstring/bstrlib.h
@@ -66,6 +66,10 @@
 extern "C" {
 #endif
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include <stdarg.h>
 #include <string.h>
 #include <limits.h>
@@ -1150,7 +1154,11 @@ typedef size_t (*bNread)(void *buff, size_t elsize, size_t nelem, void *parm);
  * character. This is consistent with the semantics of fgets.)
  */
 BSTR_PUBLIC bstring
+#if defined(HAVE_LIBGEN_H_BGETS)
+bgetstream(bNgetc getcPtr, void *parm, char terminator);
+#else
 bgets(bNgetc getcPtr, void *parm, char terminator);
+#endif
 
 /**
  * Read an entire stream into a bstring, verbatum.

--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,32 @@ add_project_arguments('-fvisibility=hidden', language: 'c')
 
 bstring_inc = include_directories(['.', 'bstring'])
 
+bgets_test_code = '''
+#include <stdio.h>
+#include <libgen.h>
+int main() {
+    char buffer[256];
+    char delim = '\n';
+    FILE *fp = stdin;
+    char *result = bgets(buffer, sizeof(buffer), fp, &delim);
+    return 0;
+}
+'''
+
+has_bgets = cc.compiles(bgets_test_code, name: 'bgets defined in standard C library')
+conf_data = configuration_data()
+
+if has_bgets or get_option('force-bgets-workaround')
+    conf_data.set('HAVE_LIBGEN_H_BGETS', '1')
+else
+    conf_data.set('HAVE_LIBGEN_H_BGETS', '0')
+endif
+
+configure_file(
+    output: 'config.h',
+    configuration: conf_data
+)
+
 subdir('bstring')
 
 pkg.generate(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,10 @@
 option(
+    'force-bgets-workaround',
+    type: 'boolean',
+    value: true,
+    description: 'Always use workaround that renames bgets function to bgetstring',
+)
+option(
     'enable-docs',
     type: 'boolean',
     value: false,

--- a/tests/bstest.c
+++ b/tests/bstest.c
@@ -35,6 +35,10 @@
  * This file is the C unit test for Bstrlib.
  */
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include "bstraux.h"
 #include "bstrlib.h"
 #include <check.h>
@@ -2466,11 +2470,19 @@ START_TEST(core_038)
 	int ret = test38_aux_bnopen(&f, &shortBstring);
 	ck_assert_int_eq(ret, 0);
 	/* Creation/reads */
+#if defined(HAVE_LIBGEN_H_BGETS)
+	b0 = bgetstream((bNgetc)test38_aux_bngetc, &f, 'b');
+#else
 	b0 = bgets((bNgetc)test38_aux_bngetc, &f, 'b');
+#endif
 	ck_assert(b0 != NULL);
 	b1 = bread((bNread)test38_aux_bnread, &f);
 	ck_assert(b1 != NULL);
+#if defined(HAVE_LIBGEN_H_BGETS)
+	b2 = bgetstream((bNgetc)test38_aux_bngetc, &f, '\0');
+#else
 	b2 = bgets((bNgetc)test38_aux_bngetc, &f, '\0');
+#endif
 	ck_assert(b2 == NULL);
 	b3 = bread((bNread)test38_aux_bnread, &f);
 	ck_assert(b3 != NULL);

--- a/tests/testaux.c
+++ b/tests/testaux.c
@@ -35,6 +35,10 @@
  * This file is the C unit test for the bstraux module of Bstrlib.
  */
 
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include "bstraux.h"
 #include "bstrlib.h"
 #include <check.h>


### PR DESCRIPTION
The Solaris standard C library defines a bgets symbol in libgen.h which conflicts with this library

https://docs.oracle.com/cd/E36784_01/html/E36877/bgets-3gen.html

This changeset introduces a build system check for this symbol and wraps a workaround in preprocessor macros

You can also force the workaround with -Dforce-bgets-workaround=true