### PR TITLE
Bump project version to 1.0.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@ AC_PREREQ([2.72])
 #	interface_age = 0
 m4_define([major_version], [1])
 m4_define([minor_version], [0])
-m4_define([micro_version], [0])
+m4_define([micro_version], [1])
 m4_define([interface_age], [0])
 
 # Initialize autoconf & automake

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('bstring', 'c', version: '1.0.0', default_options: ['warning_level=2'])
+project('bstring', 'c', version: '1.0.1', default_options: ['warning_level=2'])
 cc = meson.get_compiler('c')
 pkg = import('pkgconfig')
 


### PR DESCRIPTION
This is an underhanded way to say that I would love a stable 1.0.1 release so that there's a canonical tarball that I can reference in the Meson subproject wrapper in Netatalk. :)

At the same time, I left the library soversion at 1.0.0 because the ABI hasn't changed since the 1.0.0 release version.