### PR TITLE
meson: Do not set install_dir

### DIFF
--- a/bstring/meson.build
+++ b/bstring/meson.build
@@ -7,7 +7,6 @@ libbstring = library(
     soversion: '1',
     include_directories: bstring_inc,
     install: true,
-    install_dir: get_option('libdir'),
 )
 
 bstring_dep = declare_dependency(include_directories: bstring_inc, link_with: libbstring)


### PR DESCRIPTION
This overrides Meson defaults and breaks on some systems such as FreeBSD as paths gets incorrect