### PR TITLE
GitHub CI: Run memory profiling with valgrind on Linux and FreeBSD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,8 @@ jobs:
             gcc \
             meson \
             ninja \
-            pkgconfig
+            pkgconfig \
+            valgrind
       - name: Configure
         run: |
           meson setup build \
@@ -40,6 +41,8 @@ jobs:
         run: meson compile -C build
       - name: Run unit tests
         run: meson test -C build
+      - name: Run memory profiling
+        run: meson test --wrapper='valgrind --leak-check=full --error-exitcode=1' -C build
       - name: Install
         run: meson install -C build
       - name: Uninstall
@@ -60,7 +63,8 @@ jobs:
             gcc \
             meson \
             ninja \
-            pkgconfig
+            pkgconfig \
+            valgrind
       - name: Configure
         run: |
           meson setup build \
@@ -90,7 +94,8 @@ jobs:
             check \
             meson \
             ninja-build \
-            pkg-config
+            pkg-config \
+            valgrind
       - name: Configure
         run: |
           meson setup build \
@@ -99,6 +104,8 @@ jobs:
         run: meson compile -C build
       - name: Run unit tests
         run: meson test -C build
+      - name: Run memory profiling
+        run: meson test --wrapper='valgrind --leak-check=full --error-exitcode=1' -C build
       - name: Install
         run: meson install -C build
       - name: Uninstall
@@ -119,7 +126,8 @@ jobs:
             check-devel \
             gcc \
             meson \
-            ninja-build
+            ninja-build \
+            valgrind
       - name: Configure
         run: |
           meson setup build \
@@ -128,6 +136,8 @@ jobs:
         run: meson compile -C build
       - name: Run unit tests
         run: meson test -C build
+      - name: Run memory profiling
+        run: meson test --wrapper='valgrind --leak-check=full --error-exitcode=1' -C build
       - name: Install
         run: sudo meson install -C build
       - name: Uninstall
@@ -145,7 +155,8 @@ jobs:
           sudo apt-get install --assume-yes --no-install-recommends \
             check \
             meson \
-            ninja-build
+            ninja-build \
+            valgrind
       - name: Configure
         run: |
           meson setup build \
@@ -154,6 +165,8 @@ jobs:
         run: meson compile -C build
       - name: Run unit tests
         run: meson test -C build
+      - name: Run memory profiling
+        run: meson test --wrapper='valgrind --leak-check=full --error-exitcode=1' -C build
       - name: Install
         run: sudo meson install -C build
       - name: Uninstall
@@ -228,13 +241,15 @@ jobs:
             pkg install -y \
               check \
               meson \
-              pkgconf
+              pkgconf \
+              valgrind
           run: |
             set -e
             meson setup build \
               -Denable-tests=true
             meson compile -C build
             meson test -C build
+            meson test --wrapper='valgrind --leak-check=full --error-exitcode=1' -C build
             meson install -C build
             ninja -C build uninstall
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Builds
+name: Build and Test
 on:
   push:
     branches:

--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ only source incompatibility is the removal of the `const_bstring` type.
 
 ## Building
 
-The repository currently includes [Meson][] and Autotools ([Autoconf][],
+The repository currently includes [Meson][]+[Ninja][] and Autotools ([Autoconf][],
 [Automake][], and [Libtool][]) build systems.
 
 [Meson]: https://mesonbuild.com/
+[Ninja]: https://ninja-build.org/
 [Autoconf]: https://www.gnu.org/software/autoconf/
 [Automake]: https://www.gnu.org/software/automake/
 [Libtool]: https://www.gnu.org/software/libtool/

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ A test suite is available if Check is is installed.
 
     $ meson test -C build
 
+If Valgrind is installed the test suite can be checked for memory leaks.
+
+    $ meson test --wrapper='valgrind --leak-check=full --error-exitcode=1' -C build
+
 ### Autotools
 
 To build with Autotools:


### PR DESCRIPTION
Use the built-in valgrind wrapper in Meson to run memory profiling in the CI pipeline

It might be possible to use valgrind on other platforms than Linux and FreeBSD, but these two were the ones that worked out of the box