### PR TITLE
Check for and use no-undefined linker flag, explicitly link with libc 

### DIFF
--- a/bstring/meson.build
+++ b/bstring/meson.build
@@ -6,6 +6,8 @@ libbstring = library(
     version: '1.0.0',
     soversion: '1',
     include_directories: bstring_inc,
+    dependencies: bstring_deps,
+    link_args: linker_flags,
     install: true,
 )
 

--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,18 @@ add_project_arguments('-fno-common', language: 'c')
 add_project_arguments('-fvisibility=hidden', language: 'c')
 
 bstring_inc = include_directories(['.', 'bstring'])
+bstring_deps = []
+libc_dep = cc.find_library('c', required: false)
+
+if libc_dep.found()
+    bstring_deps += [libc_dep]
+endif
+
+linker_flags = []
+
+if cc.has_link_argument('-Wl,--no-undefined')
+    linker_flags = ['-Wl,--no-undefined']
+endif
 
 bgets_test_code = '''
 #include <stdio.h>


### PR DESCRIPTION
Check if the linker can link with '-Wl,--no-undefined' and apply the flag when linking libbstring

Also for the sake of OpenBSD, look for and explicitly link with libc in order to address the linker error that the above flag revealed