### PR TITLE
Create a SonarQube properties file

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,7 @@
+sonar.projectKey=msteinert_bstring
+sonar.organization=msteinert
+sonar.sources=.
+sonar.sourceEncoding=UTF-8
+sonar.projectName=bstring
+sonar.projectVersion=1.0
+sonar.cpd.exclusions=tests/**


### PR DESCRIPTION
Apart from boilerplate settings, this sets the project version to 1.0 for anchoring analysis records, and the following configuration that should skip code duplication analysis for test code which is inherently repetitive:

sonar.cpd.exclusions=tests/**