### PR TITLE
Prevent null pointer dereference in bwriteprotect macro usage

### DIFF
--- a/tests/bstest.c
+++ b/tests/bstest.c
@@ -54,11 +54,7 @@ test0_0(const char *s, const char *res)
 	int ret = 0;
 	bstring b0 = bfromcstr(s);
 	if (s) {
-		if (b0 == NULL) {
-			ck_abort();
-			return; /* Just a safeguard */
-		}
-		if (res == NULL) {
+		if (b0 == NULL || res == NULL) {
 			ck_abort();
 			return; /* Just a safeguard */
 		}
@@ -80,11 +76,7 @@ test0_1(const char *s, int len, const char *res)
 	int ret = 0;
 	bstring b0 = bfromcstralloc(len, s);
 	if (s) {
-		if (b0 == NULL) {
-			ck_abort();
-			return; /* Just a safeguard */
-		}
-		if (res == NULL) {
+		if (b0 == NULL || res == NULL) {
 			ck_abort();
 			return; /* Just a safeguard */
 		}
@@ -137,11 +129,7 @@ test1_0(const void *blk, int len, const char *res)
 {
 	int ret = 0;
 	bstring b0 = blk2bstr(blk, len);
-	if (res) {
-		if (b0 == NULL) {
-			ck_abort();
-			return; /* Just a safeguard */
-		}
+	if (res && b0) {
 		ck_assert_int_eq(b0->slen, len);
 		ret = memcmp(res, b0->data, len);
 		ck_assert_int_eq(ret, 0);
@@ -173,11 +161,7 @@ test2_0(const bstring b, char z, const unsigned char *res)
 {
 	int ret = 0;
 	char *s = bstr2cstr(b, z);
-	if (res) {
-		if (s == NULL) {
-			ck_abort();
-			return; /* Just a safeguard */
-		}
+	if (res && s) {
 		ret = strlen(s);
 		ck_assert_int_eq(b->slen, ret);
 		ret = memcmp(res, b->data, b->slen);
@@ -235,11 +219,9 @@ test3_0(const bstring b)
 	bstring b0 = bstrcpy(b);
 	if (!b || !b->data || b->slen < 0) {
 		ck_assert(b0 == NULL);
+	} else if (b0 == NULL) {
+		ck_abort();
 	} else {
-		if (b0 == NULL) {
-			ck_abort();
-			return; /* Just a safeguard */
-		}
 		ck_assert_int_eq(b0->slen, b->slen);
 		ret = memcmp(b->data, b0->data, b->slen);
 		ck_assert_int_eq(ret, 0);
@@ -270,11 +252,7 @@ test4_0(const bstring b, int left, int len, const char *res)
 	if (b0 == NULL) {
 		ck_assert(!b || !b->data || b->slen < 0 || len < 0);
 	} else {
-		if (b == NULL) {
-			ck_abort();
-			return; /* Just a safeguard */
-		}
-		if (res == NULL) {
+		if (b == NULL || res == NULL) {
 			ck_abort();
 			return; /* Just a safeguard */
 		}
@@ -504,18 +482,18 @@ test7x8(int (* fnptr)(const bstring, const bstring),
 	bstring b = bstrcpy(&shortBstring);
 	if (b == NULL) {
 		ck_abort();
-		return; /* Just a safeguard */
-	}
-	b->data[1]++;
-	test7x8_0(fnptr, b, &shortBstring, retGT);
-	int ret = bdestroy(b);
-	ck_assert_int_eq(ret, BSTR_OK);
-	if (fnptr == biseq) {
-		test7x8_0(fnptr, &shortBstring, &longBstring, retGT);
-		test7x8_0(fnptr, &longBstring, &shortBstring, retLT);
 	} else {
-		test7x8_0(fnptr, &shortBstring, &longBstring, 'b' - 'T');
-		test7x8_0(fnptr, &longBstring, &shortBstring, 'T' - 'b');
+		b->data[1]++;
+		test7x8_0(fnptr, b, &shortBstring, retGT);
+		int ret = bdestroy(b);
+		ck_assert_int_eq(ret, BSTR_OK);
+		if (fnptr == biseq) {
+			test7x8_0(fnptr, &shortBstring, &longBstring, retGT);
+			test7x8_0(fnptr, &longBstring, &shortBstring, retLT);
+		} else {
+			test7x8_0(fnptr, &shortBstring, &longBstring, 'b' - 'T');
+			test7x8_0(fnptr, &longBstring, &shortBstring, 'T' - 'b');
+		}
 	}
 }
 
@@ -1332,17 +1310,17 @@ test21_1(bstring b, const bstring sc, int ns)
 		l = bsplitstr (b, sc);
 		if (l == NULL) {
 			ck_abort();
-			return; /* Just a safeguard */
+		} else {
+			ck_assert_int_eq(ns, l->qty);
+			c = bjoin(l, sc);
+			ck_assert(c != NULL);
+			ret = biseq (c, b);
+			ck_assert_int_eq(ret, 1);
+			ret = bdestroy(c);
+			ck_assert_int_eq(ret, BSTR_OK);
+			ret = bstrListDestroy(l);
+			ck_assert_int_eq(ret, BSTR_OK);
 		}
-		ck_assert_int_eq(ns, l->qty);
-		c = bjoin(l, sc);
-		ck_assert(c != NULL);
-		ret = biseq (c, b);
-		ck_assert_int_eq(ret, 1);
-		ret = bdestroy(c);
-		ck_assert_int_eq(ret, BSTR_OK);
-		ret = bstrListDestroy(l);
-		ck_assert_int_eq(ret, BSTR_OK);
 	} else {
 		l = bsplitstr(b, sc);
 		ck_assert(l == NULL);

--- a/tests/bstest.c
+++ b/tests/bstest.c
@@ -1029,7 +1029,10 @@ test17_0(bstring s1, int pos, int len, char * res)
 	int ret = 0;
 	if (s1 && s1->data && s1->slen >= 0) {
 		b2 = bstrcpy(s1);
-		ck_assert(b2 != NULL);
+		if (b2 == NULL) {
+			ck_abort();
+			return; /* Just a safeguard */
+		}
 		bwriteprotect(*b2);
 		ret = bdelete(b2, pos, len);
 		ck_assert_int_eq(ret, BSTR_ERR);
@@ -1147,7 +1150,10 @@ test19_0(bstring b, int len, const char *res, int erv)
 	bstring b1 = NULL;
 	if (b && b->data && b->slen >= 0) {
 		b1 = bstrcpy(b);
-		ck_assert(b1 != NULL);
+		if (b1 == NULL) {
+			ck_abort();
+			return; /* Just a safeguard */
+		}
 		bwriteprotect(*b1);
 		ret = bpattern(b1, len);
 		ck_assert_int_eq(ret, BSTR_ERR);
@@ -1822,7 +1828,10 @@ test26_0(bstring b0, int pos, int len, const bstring b1,
 	if (b0 && b0->data && b0->slen >= 0 &&
 	    b1 && b1->data && b1->slen >= 0) {
 		b2 = bstrcpy(b0);
-		ck_assert(b2 != NULL);
+		if (b2 == NULL) {
+			ck_abort();
+			return; /* Just a safeguard */
+		}
 		bwriteprotect(*b2);
 		ret = breplace(b2, pos, len, b1, fill);
 		ck_assert_int_eq(ret, BSTR_ERR);
@@ -1882,7 +1891,10 @@ test27_0(bstring b0, const bstring b1, const char *res)
 	if (b0 && b0->data && b0->slen >= 0 &&
 	    b1 && b1->data && b1->slen >= 0) {
 		b2 = bstrcpy(b0);
-		ck_assert(b2 != NULL);
+		if (b2 == NULL) {
+			ck_abort();
+			return; /* Just a safeguard */
+		}
 		bwriteprotect(*b2);
 		ret = bassign(b2, b1);
 		ck_assert_int_eq(ret, BSTR_ERR);
@@ -2014,7 +2026,10 @@ test29_0(bstring b0, char *s, const char *res)
 	int ret = 0;
 	if (b0 && b0->data && b0->slen >= 0) {
 		b2 = bstrcpy(b0);
-		ck_assert(b2 != NULL);
+		if (b2 == NULL) {
+			ck_abort();
+			return; /* Just a safeguard */
+		}
 		bwriteprotect(*b2);
 		ret = bcatcstr(b2, s);
 		ck_assert_int_eq(ret, BSTR_ERR);
@@ -2063,7 +2078,10 @@ test30_0(bstring b0, const unsigned char *s, int len, const char *res)
 	int ret = 0;
 	if (b0 && b0->data && b0->slen >= 0) {
 		b2 = bstrcpy(b0);
-		ck_assert(b2 != NULL);
+		if (b2 == NULL) {
+			ck_abort();
+			return; /* Just a safeguard */
+		}
 		bwriteprotect(*b2);
 		ret = bcatblk(b2, s, len);
 		ck_assert_int_eq(ret, BSTR_ERR);
@@ -2126,7 +2144,10 @@ test31_0(bstring b0, const bstring find, const bstring replace,
 	    find && find->data && find->slen >= 0 &&
 	    replace && replace->data && replace->slen >= 0) {
 		b2 = bstrcpy(b0);
-		ck_assert(b2 != NULL);
+		if (b2 == NULL) {
+			ck_abort();
+			return; /* Just a safeguard */
+		}
 		bwriteprotect(*b2);
 		ret = bfindreplace(b2, find, replace, pos);
 		ck_assert_int_eq(ret, BSTR_ERR);
@@ -2158,7 +2179,10 @@ test31_1(bstring b0, const bstring find, const bstring replace,
 	    find && find->data && find->slen >= 0 &&
 	    replace && replace->data && replace->slen >= 0) {
 		b2 = bstrcpy(b0);
-		ck_assert(b2 != NULL);
+		if (b2 == NULL) {
+			ck_abort();
+			return; /* Just a safeguard */
+		}
 		bwriteprotect(*b2);
 		ret = bfindreplacecaseless(b2, find, replace, pos);
 		ck_assert_int_eq(ret, BSTR_ERR);
@@ -2321,7 +2345,10 @@ test33_0(bstring b0, const char *res)
 	int ret = 0;
 	if (b0 && b0->data && b0->slen >= 0) {
 		b2 = bstrcpy(b0);
-		ck_assert(b2 != NULL);
+		if (b2 == NULL) {
+			ck_abort();
+			return; /* Just a safeguard */
+		}
 		bwriteprotect(*b2);
 		ret = btoupper(b2);
 		ck_assert_int_eq(ret, BSTR_ERR);
@@ -2367,7 +2394,10 @@ test34_0(bstring b0, const char *res)
 	int ret = 0;
 	if (b0 != NULL && b0->data != NULL && b0->slen >= 0) {
 		b2 = bstrcpy(b0);
-		ck_assert(b2 != NULL);
+		if (b2 == NULL) {
+			ck_abort();
+			return; /* Just a safeguard */
+		}
 		bwriteprotect(*b2);
 		ret = btolower(b2);
 		ck_assert_int_eq(ret, BSTR_ERR);
@@ -2700,7 +2730,10 @@ test40_0(bstring b0, const bstring b1, int left, int len, const char *res)
 	if (b0 != NULL && b0->data != NULL && b0->slen >= 0 &&
 	    b1 != NULL && b1->data != NULL && b1->slen >= 0) {
 		b2 = bstrcpy(b0);
-		ck_assert(b2 != NULL);
+		if (b2 == NULL) {
+			ck_abort();
+			return; /* Just a safeguard */
+		}
 		bwriteprotect(*b2);
 		ret = bassignmidstr(b2, b1, left, len);
 		ck_assert_int_ne(ret, 0);


### PR DESCRIPTION
Aborts instead of asserts before using the bwriteprotect macro with a null parameter, to avoid null pointer dereference