### PR TITLE
Revert no-undefined linker logic which meson handles natively

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -298,7 +298,7 @@ jobs:
           run: |
             set -e
             meson setup build \
-              -Denable-tests=true
+              -Denable-tests=true -Db_lundef=true
             meson compile -C build
             meson test -C build
             meson install -C build

--- a/bstring/meson.build
+++ b/bstring/meson.build
@@ -7,7 +7,6 @@ libbstring = library(
     soversion: '1',
     include_directories: bstring_inc,
     dependencies: bstring_deps,
-    link_args: linker_flags,
     install: true,
 )
 

--- a/meson.build
+++ b/meson.build
@@ -13,10 +13,6 @@ bstring_inc = include_directories(['.', 'bstring'])
 bstring_deps = []
 libc_dep = cc.find_library('c', required: false)
 
-if libc_dep.found()
-    bstring_deps += [libc_dep]
-endif
-
 bgets_test_code = '''
 #include <stdio.h>
 #include <libgen.h>

--- a/meson.build
+++ b/meson.build
@@ -17,12 +17,6 @@ if libc_dep.found()
     bstring_deps += [libc_dep]
 endif
 
-linker_flags = []
-
-if cc.has_link_argument('-Wl,--no-undefined')
-    linker_flags = ['-Wl,--no-undefined']
-endif
-
 bgets_test_code = '''
 #include <stdio.h>
 #include <libgen.h>


### PR DESCRIPTION
Meson already handles the no-undefined linker flag through the -Db_lundef built-in option