### PR TITLE
Revert "Check for and use no-undefined linker flag, explicitly link with libc"

### DIFF
--- a/bstring/meson.build
+++ b/bstring/meson.build
@@ -6,8 +6,6 @@ libbstring = library(
     version: '1.0.0',
     soversion: '1',
     include_directories: bstring_inc,
-    dependencies: bstring_deps,
-    link_args: linker_flags,
     install: true,
 )
 

--- a/meson.build
+++ b/meson.build
@@ -10,18 +10,6 @@ add_project_arguments('-fno-common', language: 'c')
 add_project_arguments('-fvisibility=hidden', language: 'c')
 
 bstring_inc = include_directories(['.', 'bstring'])
-bstring_deps = []
-libc_dep = cc.find_library('c', required: false)
-
-if libc_dep.found()
-    bstring_deps += [libc_dep]
-endif
-
-linker_flags = []
-
-if cc.has_link_argument('-Wl,--no-undefined')
-    linker_flags = ['-Wl,--no-undefined']
-endif
 
 bgets_test_code = '''
 #include <stdio.h>


### PR DESCRIPTION
Revert no-undefined linker logic which meson [handles natively](https://mesonbuild.com/Builtin-options.html), namely with `-Db_lundef` which is enabled by default