### PR TITLE
Refactor a few control structures to be more gcov friendly

### DIFF
--- a/bstring/bstrlib.c
+++ b/bstring/bstrlib.c
@@ -1856,7 +1856,8 @@ breada(bstring b, bNread readPtr, void *parm)
 		return BSTR_ERR;
 	}
 	i = b->slen;
-	for (n = i + 16; ; n += ((n < BS_BUFF_SZ) ? n : BS_BUFF_SZ)) {
+	n = i + 16;
+	while (1) {
 		if (BSTR_OK != balloc(b, n + 1)) {
 			return BSTR_ERR;
 		}
@@ -1864,9 +1865,11 @@ breada(bstring b, bNread readPtr, void *parm)
 		i += l;
 		b->slen = i;
 		if (i < n) {
-			break;
+			goto done;
 		}
+		n += (n < BS_BUFF_SZ) ? n : BS_BUFF_SZ;
 	}
+done:
 	b->data[i] = (unsigned char)'\0';
 	return BSTR_OK;
 }


### PR DESCRIPTION
Use alternative control structures for two complex loops that make them parsable for the code coverage tool gcov.

Also refactored a few side-effecty conditional statements.

Resolves these warnings:

```
lcov: WARNING: (inconsistent) /home/dmark/bstring/bstring/bstraux.c:597: unexecuted block on non-branch line with non-zero hit count
lcov: WARNING: (inconsistent) /home/dmark/bstring/bstring/bstrlib.c:1859: unexecuted block on non-branch line with non-zero hit count
```