### PR TITLE
Turn the bgets workaround into a manual option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -347,6 +347,7 @@ jobs:
             set -e
             export PATH=/usr/local/sbin:/usr/local/bin:$PATH
             meson setup build \
+              -Denable-bgets-workaround=true \
               -Denable-tests=true \
               -Dpkg_config_path=/usr/lib/amd64/pkgconfig
             meson compile -C build

--- a/bstring/bstrlib.c
+++ b/bstring/bstrlib.c
@@ -1946,7 +1946,7 @@ bgetsa(bstring b, bNgetc getcPtr, void *parm, char terminator)
 }
 
 bstring
-#if defined(HAVE_LIBGEN_H_BGETS)
+#if defined(HAVE_BGETS)
 bgetstream(bNgetc getcPtr, void *parm, char terminator)
 #else
 bgets(bNgetc getcPtr, void *parm, char terminator)

--- a/bstring/bstrlib.h
+++ b/bstring/bstrlib.h
@@ -1154,7 +1154,7 @@ typedef size_t (*bNread)(void *buff, size_t elsize, size_t nelem, void *parm);
  * character. This is consistent with the semantics of fgets.)
  */
 BSTR_PUBLIC bstring
-#if defined(HAVE_LIBGEN_H_BGETS)
+#if defined(HAVE_BGETS)
 bgetstream(bNgetc getcPtr, void *parm, char terminator);
 #else
 bgets(bNgetc getcPtr, void *parm, char terminator);

--- a/meson.build
+++ b/meson.build
@@ -10,26 +10,12 @@ add_project_arguments('-fno-common', language: 'c')
 add_project_arguments('-fvisibility=hidden', language: 'c')
 
 bstring_inc = include_directories(['.', 'bstring'])
-
-bgets_test_code = '''
-#include <stdio.h>
-#include <libgen.h>
-int main() {
-    char buffer[256];
-    char delim = '\n';
-    FILE *fp = stdin;
-    char *result = bgets(buffer, sizeof(buffer), fp, &delim);
-    return 0;
-}
-'''
-
-has_bgets = cc.compiles(bgets_test_code, name: 'bgets defined in standard C library')
 conf_data = configuration_data()
 
-if has_bgets or get_option('force-bgets-workaround')
-    conf_data.set('HAVE_LIBGEN_H_BGETS', '1')
+if get_option('enable-bgets-workaround')
+    conf_data.set('HAVE_BGETS', '1')
 else
-    conf_data.set('HAVE_LIBGEN_H_BGETS', '0')
+    conf_data.set('HAVE_BGETS', '0')
 endif
 
 configure_file(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,8 +1,8 @@
 option(
-    'force-bgets-workaround',
+    'enable-bgets-workaround',
     type: 'boolean',
-    value: true,
-    description: 'Always use workaround that renames bgets function to bgetstring',
+    value: false,
+    description: 'Enable workaround that renames bgets function to bgetstring',
 )
 option(
     'enable-docs',

--- a/tests/bstest.c
+++ b/tests/bstest.c
@@ -2577,7 +2577,7 @@ START_TEST(core_038)
 	int ret = test38_aux_bnopen(&f, &shortBstring);
 	ck_assert_int_eq(ret, 0);
 	/* Creation/reads */
-#if defined(HAVE_LIBGEN_H_BGETS)
+#if defined(HAVE_BGETS)
 	b0 = bgetstream((bNgetc)test38_aux_bngetc, &f, 'b');
 #else
 	b0 = bgets((bNgetc)test38_aux_bngetc, &f, 'b');
@@ -2585,7 +2585,7 @@ START_TEST(core_038)
 	ck_assert(b0 != NULL);
 	b1 = bread((bNread)test38_aux_bnread, &f);
 	ck_assert(b1 != NULL);
-#if defined(HAVE_LIBGEN_H_BGETS)
+#if defined(HAVE_BGETS)
 	b2 = bgetstream((bNgetc)test38_aux_bngetc, &f, '\0');
 #else
 	b2 = bgets((bNgetc)test38_aux_bngetc, &f, '\0');


### PR DESCRIPTION
Rather than attempting to detect the bgets symbol dynamically, use a boolean build system flag to enable it

The code snippet we used before triggered a false positive on Ubuntu 24.04

Only Solaris 11 is known to need this workaround