### PR TITLE
Remove the SonarCube Cloud configuration file

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,0 @@
-sonar.projectKey=msteinert_bstring
-sonar.organization=msteinert
-sonar.sources=.
-sonar.sourceEncoding=UTF-8
-sonar.projectName=bstring
-sonar.projectVersion=1.0
-sonar.cpd.exclusions=tests/**


### PR DESCRIPTION
This project is configured with automatic analysis setup, so the configuration file in the repo is ignored

We should be using settings in the sonarcloud.io administrative settings instead