### PR TITLE
Check that -Wno-gnu compiler flag is supported before using

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,9 +5,12 @@ pkg = import('pkgconfig')
 add_project_arguments('-pedantic', language: 'c')
 add_project_arguments('-Wstrict-prototypes', language: 'c')
 add_project_arguments('-Wcast-align', language: 'c')
-add_project_arguments('-Wno-gnu', language: 'c')
 add_project_arguments('-fno-common', language: 'c')
 add_project_arguments('-fvisibility=hidden', language: 'c')
+
+if get_option('enable-tests') and cc.has_argument('-Wno-gnu')
+    add_project_arguments('-Wno-gnu', language: 'c')
+endif
 
 bstring_inc = include_directories(['.', 'bstring'])
 


### PR DESCRIPTION
Very old compilers, such as gcc 4.2.1 on OSX Snow Leopard / PowerPC, will error out when encountering this unsupported flag

Additionally, use this flag only when building bsting with unit test support, since the non-standard code warnings that we silence with this flag lies in libcheck that we link with