### PR TITLE
Use the full project version as library version

### DIFF
--- a/bstring/meson.build
+++ b/bstring/meson.build
@@ -3,7 +3,7 @@ install_headers(['bstraux.h', 'bstrlib.h'])
 libbstring = library(
     meson.project_name(),
     ['bstraux.c', 'bstrlib.c'],
-    version: '1.0.0',
+    version: meson.project_version(),
     soversion: '1',
     include_directories: bstring_inc,
     install: true,


### PR DESCRIPTION
The library version is used for instance by pkgconf to detect dependency versions, so it makes more sense to use the full project version here rather than a static version string that indicates ABI compatibility