### PR TITLE
Cross-platform check for compiler warning flags with Windows support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -360,3 +360,56 @@ jobs:
             meson test -C build
             meson install -C build
             ninja -C build uninstall
+
+  build-windows:
+    name: Windows (MSYS2+gcc)
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@fb197b72ce45fb24f17bf3f807a388985654d1f2 # v2.29.0
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-meson
+            mingw-w64-x86_64-ninja
+            mingw-w64-x86_64-pkg-config
+            mingw-w64-x86_64-check
+      - name: Configure
+        run: |
+          meson setup build \
+            -Denable-tests=true
+      - name: Build
+        run: meson compile -C build
+      - name: Run unit tests
+        run: meson test -C build
+      - name: Install
+        run: meson install -C build
+      - name: Uninstall
+        run: ninja -C build uninstall
+
+  ci-msvc:
+    name: Windows (MSVC)
+    runs-on: windows-latest
+    steps:
+      - name: Fetch Sources
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Setup Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: '3.x'
+      - name: Install Python Dependencies
+        run: pip install meson ninja
+      - name: Prepare MSVC
+        uses: bus1/cabuild/action/msdevshell@06ea2833eef61e9b0d0ce0d728416e617e4fb1fe # v1
+        with:
+          architecture: x64
+      - name: Configure
+        run: meson setup build
+      - name: Build
+        run: meson compile -v -C build

--- a/meson.build
+++ b/meson.build
@@ -2,21 +2,39 @@ project(
     'bstring',
     'c',
     version: '1.0.2',
-    default_options: ['warning_level=2', 'c_std=c99']
+    default_options: ['warning_level=3', 'c_std=c99']
 )
 cc = meson.get_compiler('c')
 pkg = import('pkgconfig')
+warning_flags = []
 
-add_project_arguments('-pedantic', language: 'c')
-add_project_arguments('-Wstrict-prototypes', language: 'c')
-add_project_arguments('-Wcast-align', language: 'c')
-add_project_arguments('-fno-common', language: 'c')
-add_project_arguments('-fvisibility=hidden', language: 'c')
+foreach flag: [
+    '-fno-common',
+    '-fvisibility=hidden',
+    '-Wstrict-prototypes',
+    '-Wcast-align',
+]
+    if cc.has_argument(flag)
+        warning_flags += flag
+    endif
+endforeach
 
 if get_option('enable-tests') and cc.has_argument('-Wno-gnu')
-    add_project_arguments('-Wno-gnu', language: 'c')
+    warning_flags += '-Wno-gnu'
 endif
 
+if cc.get_id() == 'msvc'
+    foreach flag: [
+        '/we4431',
+        '/w14826',
+    ]
+        if cc.has_argument(flag)
+            warning_flags += flag
+        endif
+    endforeach
+endif
+
+add_project_arguments(warning_flags, language: 'c')
 bstring_inc = include_directories(['.', 'bstring'])
 conf_data = configuration_data()
 


### PR DESCRIPTION
When using Microsoft Visual C on Windows, use a different set of warning flags than with the usual Unix compilers

Also, use warning_level=3 to get the -Wpedantic flag rather than hard coding it

Create Windows build jobs in the GitHub workflow: First build uses gcc in an MSYS2 environment, the second native Microsoft Visual C