### PR TITLE
remove invalid # chars from documentation

### DIFF
--- a/bstring/bstrlib.h
+++ b/bstring/bstrlib.h
@@ -94,7 +94,7 @@ struct tagbstring {
  * Take a standard C library style '\0' terminated char buffer and generate
  * a bstring with the same contents as the char buffer.
  *
- * If an error occurs #NULL is returned.
+ * If an error occurs NULL is returned.
  *
  * \code
  * bstring b = bfromcstr("Hello");

--- a/doc/comparisons.md
+++ b/doc/comparisons.md
@@ -362,7 +362,7 @@ networking/realtime programming. It can be found [online](http://www.and.org/vst
    thread safe.
 
 The implementation has an extreme emphasis on performance for nontrivial
-actions (adds, inserts and deletes are all constant or roughly O(#operations)
+actions (adds, inserts and deletes are all constant or roughly O(\#operations)
 time) following the "zero copy" principle. This trades off performance of
 trivial functions (character access, char buffer access/coersion, alias
 detection) which becomes significantly slower, as well as incremental


### PR DESCRIPTION
In doxygen, a # is used to create a reference to a documented entity

This corrects two instances where this was used incorrectly, which triggered unexpected errors when running doxygen in strict mode (WARN_AS_ERROR=YES)

https://www.doxygen.nl/manual/commands.html#cmdhash