### PR TITLE
pkg-config should look for headers in include root

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -56,7 +56,6 @@ pkg.generate(
     name: meson.project_name(),
     description: 'The Better String Library',
     version: meson.project_version(),
-    subdirs: ['bstring'],
 )
 
 check = dependency('check', required: false)


### PR DESCRIPTION
Since meson installs the bstring headers directly into the include dir, the pkg-config file should also point to the root include dir rather than a bstring subdir

This fixes a mismatch that existed since the meson build system was introduced for this library