### PR TITLE
Upgrade FreeBSD VM action to version 1.3.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -288,8 +288,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Build on VM
-        uses: vmactions/freebsd-vm@670398e4236735b8b65805c3da44b7a511fb8b27 # v1.3.0
+        uses: vmactions/freebsd-vm@9832a7f21715c1303a1b9e7c00f96508266b4e09 # v1.3.6
         with:
+          release: "14.3"
           copyback: true
           sync: sshfs
           prepare: |


### PR DESCRIPTION
Updated FreeBSD VM action version while downgrading to v14.3 as a workaround for a broken valgrind on v15.0