### PR TITLE
rename namespace pollution meson option and define in config.h

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -34,10 +34,6 @@ if cc.get_id() == 'msvc'
     endforeach
 endif
 
-if get_option('reduce-namespace-pollution')
-    add_project_arguments('-DBSTRLIB_REDUCE_NAMESPACE_POLLUTION', language: 'c')
-endif
-
 if get_option('enable-fuzzing')
     if cc.get_id() != 'clang'
         error('Fuzz targets require clang (set CC=clang)')
@@ -51,6 +47,10 @@ endif
 add_project_arguments(warning_flags, language: 'c')
 bstring_inc = include_directories(['.', 'bstring'])
 conf_data = configuration_data()
+
+if not get_option('enable-old-api')
+    conf_data.set('BSTRLIB_REDUCE_NAMESPACE_POLLUTION', 1)
+endif
 
 if get_option('enable-bgets-workaround')
     conf_data.set('HAVE_BGETS', '1')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -17,10 +17,10 @@ option(
     description: 'Build libFuzzer fuzz targets (requires clang)',
 )
 option(
-    'fuzz-link-arg',
-    type: 'string',
-    value: '-fsanitize=fuzzer,address',
-    description: 'Linker flag used for fuzz targets (ClusterFuzzLite passes LIB_FUZZING_ENGINE here)',
+    'enable-old-api',
+    type: 'boolean',
+    value: false,
+    description: 'Enable backward compatibility macros for pre-1.0 API',
 )
 option(
     'enable-tests',
@@ -35,8 +35,8 @@ option(
     description: 'Build bstring library with UTF-8 support',
 )
 option(
-    'reduce-namespace-pollution',
-    type: 'boolean',
-    value: true,
-    description: 'Hide backward-compatibility macros in bstraux.h',
+    'fuzz-link-arg',
+    type: 'string',
+    value: '-fsanitize=fuzzer,address',
+    description: 'Linker flag used for fuzz targets (ClusterFuzzLite passes LIB_FUZZING_ENGINE here)',
 )


### PR DESCRIPTION
the new option name emphasizes the enabling of backwards compatibility API macros, which is a more constructive and actionable than 'namespace pollution'

meson previously defined BSTRLIB_REDUCE_NAMESPACE_POLLUTION as a compiler option, but now we use config.h instead for transparency